### PR TITLE
adding a Jekyll build action

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -1,0 +1,20 @@
+name: Jekyll site CI
+
+on:
+  push:
+    branches: [ gh-pages ]
+  pull_request:
+    branches: [ gh-pages ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build the site in the jekyll/builder container
+      run: |
+        docker run \
+        -v ${{ github.workspace }}:/srv/jekyll -v ${{ github.workspace }}/_site:/srv/jekyll/_site \
+        jekyll/builder:latest /bin/bash -c "chmod 777 /srv/jekyll && jekyll build --future"

--- a/_config.yml
+++ b/_config.yml
@@ -48,7 +48,7 @@ kind: "workshop"
 # Magic to make URLs resolve both locally and on GitHub.
 # See https://help.github.com/articles/repository-metadata-on-github-pages/.
 # Please don't change it: <USERNAME>/<PROJECT> is correct.
-repository: <USERNAME>/<PROJECT>
+repository: UCSBCarpentry/2020-05-29-UCSB-R
 
 # Email address, no mailto:
 # (Don't change this -- the contact address for your workshop will be set 


### PR DESCRIPTION
### effect of this change:  

When a commit is pushed to the `gh-pages` branch Google will run a Jekyll build and one can see the results in the _Actions_ tab.  This will allow you to see any errors that might occur.  

Previously the only way to see Jekyll build errors was to have Jekyll installed locally and do the build on your own computer watching the command line console for errors.

Hopefully this will make troubleshooting Jekyll errors easier.

